### PR TITLE
Change max_args to 1 in command.py, add "as" for renaming query in controller.py

### DIFF
--- a/ckanext/ga_report/command.py
+++ b/ckanext/ga_report/command.py
@@ -41,7 +41,7 @@ class GetAuthToken(CkanCommand):
     """
     summary = __doc__.split('\n')[0]
     usage = __doc__
-    max_args = 0
+    max_args = 1 
     min_args = 0
 
     def command(self):
@@ -64,7 +64,7 @@ class FixTimePeriods(CkanCommand):
     """
     summary = __doc__.split('\n')[0]
     usage = __doc__
-    max_args = 0
+    max_args = 1 
     min_args = 0
 
     def __init__(self, name):

--- a/ckanext/ga_report/controller.py
+++ b/ckanext/ga_report/controller.py
@@ -475,7 +475,7 @@ def _get_top_publishers(limit=100):
     month = c.month or 'All'
     connection = model.Session.connection()
     q = """
-        select department_id, sum(pageviews::int) views, sum(visits::int) visits
+        select department_id, sum(pageviews::int) as views, sum(visits::int) as visits
         from ga_url
         where department_id <> ''
           and package_id <> ''
@@ -502,7 +502,7 @@ def _get_top_publishers_graph(limit=20):
     '''
     connection = model.Session.connection()
     q = """
-        select department_id, sum(pageviews::int) views
+        select department_id, sum(pageviews::int) as views
         from ga_url
         where department_id <> ''
           and package_id <> ''

--- a/ckanext/ga_report/download_analytics.py
+++ b/ckanext/ga_report/download_analytics.py
@@ -655,13 +655,14 @@ class DownloadAnalytics(object):
             results = dict(url=[])
 
         result_data = results.get('rows')
-        data = {}
-        for result in result_data:
-            data[result[0]] = data.get(result[0], 0) + int(result[2])
-        ga_model.update_sitewide_stats(period_name, "Mobile brands", data, period_complete_day)
+        if result_data: 
+            data = {}
+            for result in result_data:
+                data[result[0]] = data.get(result[0], 0) + int(result[2])
+            ga_model.update_sitewide_stats(period_name, "Mobile brands", data, period_complete_day)
 
-        data = {}
-        for result in result_data:
-            data[result[1]] = data.get(result[1], 0) + int(result[2])
-        ga_model.update_sitewide_stats(period_name, "Mobile devices", data, period_complete_day)
+            data = {}
+            for result in result_data:
+                data[result[1]] = data.get(result[1], 0) + int(result[2])
+            ga_model.update_sitewide_stats(period_name, "Mobile devices", data, period_complete_day)
 


### PR DESCRIPTION
1. Change max_args to 1 in command.py, so that `paster getauthtoken credentials.json --config=/etc/ckan/default/development.ini` does not give the error `the maximum parameter is 0`.
2. Add `as` for renaming query in controller.py.  `select department_id, sum(pageviews::int) views, sum(visits::int) visits` is not working in postgreSQL 9.4. The funny reason is that  when we use `select deparment_id, sum(pageviews::int) views`, the `views` is a reserved keyword in postgresSQL9.4 and it will cause errors if we use it as the column name here. So I change the code to `select department_id, sum(pageviews::int) as views, sum(visits::int) as visits`, and this change also works for older version of postgresSQL.
